### PR TITLE
Fix build with recent glibc

### DIFF
--- a/src/setup/setup.c
+++ b/src/setup/setup.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>


### PR DESCRIPTION
Including <sys/sysmacros.h> is needed to build using recent glibc Versions.